### PR TITLE
Remove the omission of width and height

### DIFF
--- a/src/async-image/async-image.types.ts
+++ b/src/async-image/async-image.types.ts
@@ -9,11 +9,10 @@ import type { TransitionProps } from 'transitions-kit'
 
 type PX = `${number}px`
 type RootMargin = `${PX} ${PX} ${PX} ${PX}` | `${PX} ${PX} ${PX}` | `${PX} ${PX}` | `${PX}`
-type ImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'height' | 'width'>
 
 export type SourceProps = Omit<SourceHTMLAttributes<HTMLSourceElement>, 'src'> & { srcSet: string }
 
-export interface AsyncImageProps extends ImageProps {
+export interface AsyncImageProps extends ImgHTMLAttributes<HTMLImageElement> {
 	src: string
 	sources?: SourceProps[]
 	rootMargin?: RootMargin


### PR DESCRIPTION
Allow height and width in props.  I can't find any docs or commits related to why these are omitted